### PR TITLE
Upgrade zetasql

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -250,13 +250,13 @@ http_archive(
     url = "https://github.com/gflags/gflags/archive/a738fdf9338412f83ab3f26f31ac11ed3f3ec4bd.zip",
 )
 
-ZETASQL_COMMIT = "ac37cf5c0d80b5605176fc0f29e87b12f00be693" # 08/10/2022
+ZETASQL_COMMIT = "f764f4e986ac1516ab5ae95e6d6ce2f4416cc6ff" # 02/03/2023
 http_archive(
     name = "com_google_zetasql",
     urls = ["https://github.com/google/zetasql/archive/%s.zip" % ZETASQL_COMMIT],
     strip_prefix = "zetasql-%s" % ZETASQL_COMMIT,
     #patches = ["//ml_metadata/third_party:zetasql.patch"],
-    sha256 = '651a768cd51627f58aa6de7039aba9ddab22f4b0450521169800555269447840'
+    sha256 = '27e3d8bfd1f76918fc4d7a8f29646b8a0cdca567f921e0bff4a07f79448e92c0'
 )
 
 load("@com_google_zetasql//bazel:zetasql_deps_step_1.bzl", "zetasql_deps_step_1")


### PR DESCRIPTION
Upgrade zetasql to https://github.com/google/zetasql/tree/2023.03.2

With this additional upgrade  I was able to build ml-metadata multiple times by running:
```bash
# set version
export USE_BAZEL_VERSION=5.3.0

# clean
bazelisk clean --expunge

# build
bazelisk build -c opt --define grpc_no_ares=true  //ml_metadata/metadata_store:metadata_store_server
```

Note that for my use case the tracked dependencies (i.e., `bazel-*` directories) were broken, that's why I had to enforce to re-download them with a cleanup.

Env:
- Bazel: 5.3.0
- OS: Fedora release 38 (Thirty Eight)
- GCC: gcc (GCC) 13.2.1 20231011 (Red Hat 13.2.1-4)
- CLang: clang version 16.0.6 (Fedora 16.0.6-3.fc38)